### PR TITLE
updated Docker platform version for ElasticBeanstalk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
-  "name": "twine-deploy",
+  "name": "deploy",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.441.0",
-        "@aws-sdk/client-ec2": "^3.441.0",
         "@aws-sdk/client-elastic-beanstalk": "^3.445.0",
         "@aws-sdk/client-route-53": "^3.445.0",
         "@aws-sdk/credential-provider-ini": "^3.441.0",
@@ -164,67 +163,6 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudformation/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2": {
-      "version": "3.441.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.441.0.tgz",
-      "integrity": "sha512-McCx6xHOtBMnGYtpDI1O+MwnipI7Ck705XPPtf30jmhnPJk5oGi9Gnp9wWmOIPfog4R7t7wUwUr49BYCymsigQ==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.441.0",
-        "@aws-sdk/core": "3.441.0",
-        "@aws-sdk/credential-provider-node": "3.441.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-sdk-ec2": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
-        "@smithy/util-waiter": "^2.0.12",
-        "fast-xml-parser": "4.2.5",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
@@ -917,24 +855,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-ec2": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.433.0.tgz",
-      "integrity": "sha512-R/L0Z9evCaoxmdYKJWFiibi0vcucZjuUruT97X/FRbCoMUcAUlAm+WS4KiIN+jSEzcrFjG3yvcoPZdNbtS0KlQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-format-url": "3.433.0",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/signature-v4": "^2.0.0",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-sdk-route53": {
       "version": "3.433.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-route53/-/middleware-sdk-route53-3.433.0.tgz",
@@ -1075,20 +995,6 @@
       "dependencies": {
         "@aws-sdk/types": "3.433.0",
         "@smithy/util-endpoints": "^1.0.2",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.433.0.tgz",
-      "integrity": "sha512-Z6T7I4hELoQ4eeIuKIKx+52B9bc3SCPhjgMcFAFQeesjmHAr0drHyoGNJIat6ckvgI6zzFaeaBZTvWDA2hyDkA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/querystring-builder": "^2.0.12",
-        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {

--- a/templates/cloudformation.yaml
+++ b/templates/cloudformation.yaml
@@ -12,7 +12,8 @@ Parameters:
   SolutionStackName:
     Type: String
     Description: The name of an Elastic Beanstalk supported platform version
-    Default: '64bit Amazon Linux 2023 v4.1.0 running Docker'
+    # Default: '64bit Amazon Linux 2023 v4.1.0 running Docker'
+    Default: '64bit Amazon Linux 2023 v4.2.1 running Docker'
   EnvironmentRegion:
     Type: String
     Description: The AWS Region where the application will be deployed


### PR DESCRIPTION
**Description**
Twine deployment failed with the following error `'64bit Amazon Linux 2023 v4.1.0 running Docker' not found`

**Bug fix**
Update ElasticBeanstalk's supported platform version of Docker to the latest version `v4.2.1`

**QA Steps**
Run `aws elasticbeanstalk list-available-solution-stacks` and you can see for yourself that `'64bit Amazon Linux 2023 v4.1.0 running Docker'` is no longer listed. 

You can also try...

- deploying a new instance of Twine to your AWS account to see if you get the error stated above.
- If you do, update the Docker platform version within the `CloudFormation.yaml` file by changing the default `SolutionStackName` (line 15) to the latest version, `v4.2.1`. 
  - So, that line should read `Default: '64bit Amazon Linux 2023 v4.2.1 running Docker'`
- Deploy Twine again, which should be successful this time
